### PR TITLE
fix: update workflow to use python.getStdoutContent()

### DIFF
--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -9,7 +9,7 @@ wf.body(func(args) {
 		arg(args.name).
 		saveStdoutContent().
 		run()
-	pythonMessage := python.getStdoutFileContent()
+	pythonMessage := python.getStdoutContent()
 
 	tengoMessage := "Hello from Tengo, " + args.name + "!"
 


### PR DESCRIPTION
# Description
Use `python.getStdoutContent()` instead of `python.getStdoutFileContent()` in the main workflow to resolve error in the pythonMessage output of the block boilerplate.

This will allow default block boilerplate to work out of the box for users.

# Errors
<img width="1439" height="900" alt="Screenshot 2026-01-21 at 8 57 53 AM" src="https://github.com/user-attachments/assets/83267a6a-dcae-4c5f-ae7f-cebf611e423c" />

<details>
  <summary>pythonMessage Error Text - Click to Expand</summary>

```bash
pythonMessage
PlQuickJSError: PlErrorReport: resource: UserProject:2, NG:0x404/0c1f336f-fb62-48b3-b651-e2a571f439a8-prodOutput

PlTengoError:
message:
Runtime Error: cannot get element from strictMap: key "getStdoutFileContent" not found
template: @platforma-open/test-org.hello-world-issue.workflow:main@1.0.0
tengo stacktrace:
at @platforma-open/test-org.hello-world-issue.workflow:main:12:26
	at @platforma-sdk/workflow-tengo:workflow:377:14
	at @platforma-sdk/workflow-tengo:tpl.base:672:16
	at @platforma-sdk/workflow-tengo:tpl.base:575:5
	at @platforma-sdk/workflow-tengo:workflow:374:3
	at @platforma-open/test-org.hello-world-issue.workflow:main:6:1

raw message:
[I] "NG:0x1BDEE/resource": has input errors:
cannot eval code: cannot eval template: template: @platforma-open/test-org.hello-world-issue.workflow:main@1.0.0
	Runtime Error: cannot get element from strictMap: key "getStdoutFileContent" not found
	at @platforma-open/test-org.hello-world-issue.workflow:main:12:26
	at @platforma-sdk/workflow-tengo:workflow:377:14
	at @platforma-sdk/workflow-tengo:tpl.base:672:16
	at @platforma-sdk/workflow-tengo:tpl.base:575:5
	at @platforma-sdk/workflow-tengo:workflow:374:3
	at @platforma-open/test-org.hello-world-issue.workflow:main:6:1


QuickJS stacktrace:
PlErrorReport/uuid:21407ef2-e571-4744-be74-43f812a5ae98: 
    at getNamedAccessor (bundle.js:7272)
    at get outputs (bundle.js:7278)
    at <anonymous> (bundle.js)
    at <anonymous> (bundle.js)
Host: PlErrorReport/uuid:21407ef2-e571-4744-be74-43f812a5ae98: 
    at QuickJSContext.unwrapResult (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/quickjs-emscripten-core/dist/chunk-JTKJZQYV.mjs:4:24443)
    at file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/context.js:72:50
    at _Scope.withScope (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/quickjs-emscripten-core/dist/chunk-JTKJZQYV.mjs:4:402)
    at JsExecutionContext.runCallback (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/context.js:68:26)
    at Object.___kernel___ (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/index.js:95:33)
    at renderSelfState (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:270:32)
    at updateCellStateWithoutValue (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:427:11)
    at calculateChildren (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:300:24)
    at updateCellStateWithoutValue (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:431:28)
    at calculateChildren (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:300:24)

```
</details>

<details>
  <summary>tengoMessage Error Text - Click to Expand</summary>

```bash
tengoMessage
PlQuickJSError: PlErrorReport: resource: UserProject:2, NG:0x404/0c1f336f-fb62-48b3-b651-e2a571f439a8-prodOutput

PlTengoError:
message:
Runtime Error: cannot get element from strictMap: key "getStdoutFileContent" not found
template: @platforma-open/test-org.hello-world-issue.workflow:main@1.0.0
tengo stacktrace:
at @platforma-open/test-org.hello-world-issue.workflow:main:12:26
	at @platforma-sdk/workflow-tengo:workflow:377:14
	at @platforma-sdk/workflow-tengo:tpl.base:672:16
	at @platforma-sdk/workflow-tengo:tpl.base:575:5
	at @platforma-sdk/workflow-tengo:workflow:374:3
	at @platforma-open/test-org.hello-world-issue.workflow:main:6:1

raw message:
[I] "NG:0x1BDEE/resource": has input errors:
cannot eval code: cannot eval template: template: @platforma-open/test-org.hello-world-issue.workflow:main@1.0.0
	Runtime Error: cannot get element from strictMap: key "getStdoutFileContent" not found
	at @platforma-open/test-org.hello-world-issue.workflow:main:12:26
	at @platforma-sdk/workflow-tengo:workflow:377:14
	at @platforma-sdk/workflow-tengo:tpl.base:672:16
	at @platforma-sdk/workflow-tengo:tpl.base:575:5
	at @platforma-sdk/workflow-tengo:workflow:374:3
	at @platforma-open/test-org.hello-world-issue.workflow:main:6:1


QuickJS stacktrace:
PlErrorReport/uuid:51970e36-3dc5-4054-933e-e8b826c46656: 
    at getNamedAccessor (bundle.js:7272)
    at get outputs (bundle.js:7278)
    at <anonymous> (bundle.js)
    at <anonymous> (bundle.js)
Host: PlErrorReport/uuid:51970e36-3dc5-4054-933e-e8b826c46656: 
    at QuickJSContext.unwrapResult (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/quickjs-emscripten-core/dist/chunk-JTKJZQYV.mjs:4:24443)
    at file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/context.js:72:50
    at _Scope.withScope (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/quickjs-emscripten-core/dist/chunk-JTKJZQYV.mjs:4:402)
    at JsExecutionContext.runCallback (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/context.js:68:26)
    at Object.___kernel___ (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/pl-middle-layer/dist/js_render/index.js:95:33)
    at renderSelfState (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:270:32)
    at updateCellStateWithoutValue (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:427:11)
    at calculateChildren (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:300:24)
    at updateCellStateWithoutValue (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:431:28)
    at calculateChildren (file:///Applications/Platforma.app/Contents/Resources/app.asar/node_modules/@milaboratories/computable/dist/computable/computable_state.js:300:24)

```
</details>

# After Fix
<img width="1437" height="527" alt="Screenshot 2026-01-21 at 9 00 22 AM" src="https://github.com/user-attachments/assets/c2197ade-ecdf-4ef5-a254-c872e25f8dbd" />

