### PR TITLE
Add build:docker-dev script for dev ECR pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "turbo run check",
     "build": "turbo run build",
     "build:dev": "env PL_PKG_DEV=local turbo run build",
-    "build:docker-dev": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build --force",
+    "build:dev-remote": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build --force",
     "test": "env PL_PKG_DEV=local turbo run test --concurrency 1 --env-mode=loose",
     "test:dry-run": "env PL_PKG_DEV=local turbo run test --dry-run=json",
     "mark-stable": "turbo run mark-stable",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "turbo run check",
     "build": "turbo run build",
     "build:dev": "env PL_PKG_DEV=local turbo run build",
+    "build:docker-dev": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build --force",
     "test": "env PL_PKG_DEV=local turbo run test --concurrency 1 --env-mode=loose",
     "test:dry-run": "env PL_PKG_DEV=local turbo run test --dry-run=json",
     "mark-stable": "turbo run mark-stable",

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,17 @@
     "build": {
       "dependsOn": ["^build", "check"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+      "env": [
+        "PL_PKG_DEV",
+        "PL_PKG_FULL_HASH",
+        "PL_PKG_VERSION",
+        "PL_DOCKER_REGISTRY",
+        "PL_DOCKER_BUILD",
+        "PL_DOCKER_NO_BUILD",
+        "PL_DOCKER_AUTOPUSH",
+        "PL_DOCKER_NO_AUTOPUSH",
+        "PL_DOCKER_REGISTRY_PUSH_TO"
+      ],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
     },
     "build:dev": {


### PR DESCRIPTION
## Summary

Companion to [milaboratory/platforma#1613](https://github.com/milaboratory/platforma/pull/1613), which adds a docker build + push flow to `@platforma-sdk/package-builder`. By design, `pnpm run build:dev` does **not** push docker (block devs run it on every save). To publish a dev image to the shared dev ECR, devs invoke a separate script.

## Changes

### `package.json`

```json
"build:docker-dev": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build --force"
```

- `PL_DOCKER_BUILD=1` + `PL_DOCKER_AUTOPUSH=1` — explicit opt-in to docker build + push.
- `--force` — bypasses turbo cache so the build runs even when `build:dev`'s prior cached outputs would otherwise satisfy the task.

### `turbo.json`

Extend the `build` task's `env` list so the dev/docker knobs actually reach `pl-pkg` under turbo's default strict env mode (unlisted vars are dropped):

- `PL_PKG_DEV`, `PL_PKG_FULL_HASH`, `PL_PKG_VERSION`
- `PL_DOCKER_REGISTRY`, `PL_DOCKER_BUILD`, `PL_DOCKER_NO_BUILD`
- `PL_DOCKER_AUTOPUSH`, `PL_DOCKER_NO_AUTOPUSH`, `PL_DOCKER_REGISTRY_PUSH_TO`

All in `env` (vs `passThroughEnv`) on first adoption — most affect output (dev mode flips `.sw.json` shape; `PL_DOCKER_REGISTRY` ends up in `docker.tag`). Push-only flags could be moved to `passThroughEnv` for cleaner cache semantics later.

## Test plan

In a block created from this boilerplate (with the new `@platforma-sdk/package-builder` from milaboratory/platforma#1613):

- [ ] `pnpm run build:dev` does **not** build or push docker (look for absence of `Building docker images...` / `Publishing docker image…`).
- [ ] `pnpm run build:docker-dev` builds + pushes, and on a same-source rerun produces `Skipping push...` (idempotent).
- [ ] `.sw.json` after `build:docker-dev` carries `docker.tag` pointing at the dev ECR; after plain `build:dev` it does not.