### PR TITLE
chore: bump package-builder to 3.13.0 for docker cross-compile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 1.64.0
       version: 1.64.0
     '@platforma-sdk/package-builder':
-      specifier: 3.12.0
-      version: 3.12.0
+      specifier: 3.13.0
+      version: 3.13.0
     '@platforma-sdk/tengo-builder':
       specifier: 2.5.8
       version: 2.5.8
@@ -121,7 +121,7 @@ importers:
         version: 1.7.8
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
-        version: 3.12.0
+        version: 3.13.0
 
   test:
     dependencies:
@@ -1344,8 +1344,8 @@ packages:
   '@platforma-sdk/model@1.64.0':
     resolution: {integrity: sha512-l1Y/rDcOkW0EJJBJVdbXjLZFoGLyRBaV3ZQPizdh/h8Zts8CVifvmUM1Oz6/wBjs23gSY10/wiwzf70dc0DC9A==}
 
-  '@platforma-sdk/package-builder@3.12.0':
-    resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
+  '@platforma-sdk/package-builder@3.13.0':
+    resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
     hasBin: true
 
   '@platforma-sdk/tengo-builder@2.5.8':
@@ -4049,6 +4049,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -6117,7 +6118,7 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/package-builder@3.12.0':
+  '@platforma-sdk/package-builder@3.13.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   "@platforma-sdk/ui-vue": 1.64.0
   "@platforma-sdk/test": 1.64.0
   "@platforma-sdk/tengo-builder": 2.5.8
-  "@platforma-sdk/package-builder": 3.12.0
+  "@platforma-sdk/package-builder": 3.13.0
   "@platforma-sdk/blocks-deps-updater": 2.2.0
 
   "@platforma-open/milaboratories.runenv-python-3": 1.7.8


### PR DESCRIPTION
## Problem

The boilerplate ships the `build:dev-remote` script:

```
"build:dev-remote": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build"
```

but pins `@platforma-sdk/package-builder` at **3.12.0**, which hard-gates docker image builds to x64 hosts (`dockerArchitectures = ["x64"]`). On Apple Silicon (aarch64) Macs the docker step is silently skipped — the Dockerfile is generated but `docker build` never runs:

```
warn: Docker image generation was skipped because host architecture 'aarch64'
      is currently not supported by Platforma Backend docker feature
```

So `build:dev-remote` is effectively a no-op on the most common dev machine.

## Fix

Bump `@platforma-sdk/package-builder` to **3.13.0** (and refresh the lockfile). 3.13.0:

- drops the host-arch gate and cross-compiles to `linux/amd64` via qemu on non-x64 hosts (keeps a CI-side strict-platform gate so only the linux/x64 matrix leg builds + pushes);
- pins `--platform linux/amd64` and disables buildkit SLSA provenance + SBOM so identical source yields a stable digest (smart-skip on re-push works);
- is the version that introduced the `build:dev-remote` flow itself.

## Verification

Bumping to 3.13.0 in a downstream block (`gpu-test`) and running the docker build on an Apple Silicon Mac now produces the image instead of skipping:

```
info: Docker image is built:
  tag: 'public.ecr.aws/u5p1x5q2/pl-containers:...gpu-info.main.bb4ac189ec21'
  location file: '.../dist/artifacts/main/docker_x64.json'
```