### PR TITLE
ci: build generated blocks on hz runners + RGW cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   init:
     if: github.repository != 'milaboratory/platforma-block-boilerplate'
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - uses: milaboratory/github-ci/actions/context/init@v4
         with:
@@ -29,6 +29,7 @@ jobs:
       app-name-slug: 'block-block-boilerplate'
 
       node-version: '20.x'
+      gha-runner-label: hz-ubuntu-dind
       build-script-name: 'build'
       pnpm-recursive-build: false
 
@@ -66,6 +67,15 @@ jobs:
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
           "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+
+          "HZ_CI_TURBO_S3_BUCKET": ${{ toJSON(vars.HZ_CI_TURBO_S3_BUCKET) }},
+          "HZ_CI_TURBO_S3_ENDPOINT": ${{ toJSON(vars.HZ_CI_TURBO_S3_ENDPOINT) }},
+          "HZ_CI_TURBO_S3_REGION": ${{ toJSON(vars.HZ_CI_TURBO_S3_REGION) }},
+          "HZ_CI_TURBO_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_ACCESS_KEY) }},
+          "HZ_CI_TURBO_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_SECRET_KEY) }},
+          "HZ_CI_CACHE_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_ACCESS_KEY) }},
+          "HZ_CI_CACHE_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_SECRET_KEY) }},
+
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }


### PR DESCRIPTION
## What
Generated blocks now build on the **Hetzner hz runners** with **RGW-backed caches**, matching the platforma monorepo:
- `init` + `gha-runner-label: hz-ubuntu-dind` → whole pipeline on hz
- `secrets.env` gains `HZ_CI_TURBO_S3_*` + `HZ_CI_CACHE_S3_*` → turbo + pnpm store cache to RGW (via `node-simple-pnpm@v4`, everpcpc/OpenDAL fix now on `@v4`)

## Reference
Proven end-to-end on `platforma-open/clonotype-space@test/hz-runner-rgw-cache` (all jobs on hz, turbo+pnpm caches hit RGW, CiliumNetworkPolicy egress lockdown live).

## Prerequisite for generated repos
The `HZ_CI_TURBO_S3_*` / `HZ_CI_CACHE_S3_*` org secrets/vars must be **in scope** for each generated block repo (currently scoped to a subset). Without them the runner still works; caches gracefully fall back to GitHub.